### PR TITLE
[fix] python3 coral transform write binary

### DIFF
--- a/backend_utils/coral_fit_and_transform.py
+++ b/backend_utils/coral_fit_and_transform.py
@@ -43,7 +43,7 @@ transform_ood_vec = np.dot(np.dot(ood_vec, whitening), coloring)
 if not os.path.isdir(transform_dir):
     os.makedirs(transform_dir)
 
-with open(os.path.join(transform_dir, 'xvector_transformed.ark'), 'w') as f:
+with open(os.path.join(transform_dir, 'xvector_transformed.ark'), 'wb') as f:
     for index, key in enumerate(ood_keys):
         kaldi_io.write_vec_flt(f, transform_ood_vec[index], key=key)
         


### PR DESCRIPTION
Fixed python3 `AssertionError` when saving CORAL transform results
```
Traceback (most recent call last):
  File "backend_utils/coral_fit_and_transform.py", line 48, in <module>
    kaldi_io.write_vec_flt(f, transform_ood_vec[index], key=key)
  File "/media/ssdraid0/okhotnikov/git/kaldi/egs/sre19/Backends-for-SRE19/backend_utils/kaldi_io.py", line 932, in write_vec_flt
    if sys.version_info[0] == 3: assert(fd.mode == 'wb')
AssertionError
```